### PR TITLE
Use float datatype, use fastutil collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,18 @@
                     <argLine>-Xmx256M</argLine>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>quickdt</groupId>
     <artifactId>quickdt</artifactId>
-    <version>0.0.8.11-TS2</version>
+    <version>0.0.8.11-TS3</version>
     <distributionManagement>
         <repository>
             <id>gh-pages</id>
@@ -24,6 +24,11 @@
         </repository>
     </repositories>
     <dependencies>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>7.0.7</version>
+        </dependency>
         <dependency>
             <groupId>com.twitter.common</groupId>
             <artifactId>stats-util</artifactId>

--- a/src/main/java/quickdt/ClassificationCounter.java
+++ b/src/main/java/quickdt/ClassificationCounter.java
@@ -1,16 +1,17 @@
 package quickdt;
 
 import com.google.common.collect.Maps;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
+import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import org.javatuples.Pair;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 public class ClassificationCounter implements Serializable {
-	private final Map<Serializable, Double> counts = Maps.newHashMap();
+	private final Object2DoubleMap<Serializable> counts = new Object2DoubleOpenHashMap<Serializable>();
 
 	private double total = 0;
 
@@ -33,8 +34,8 @@ public class ClassificationCounter implements Serializable {
 		return Pair.with(totals, result);
 	}
 
-    public Map<Serializable, Double> getCounts() {
-        return Collections.unmodifiableMap(counts);
+    public Object2DoubleMap<Serializable> getCounts() {
+        return Object2DoubleMaps.unmodifiable(counts);
     }
 
 
@@ -47,20 +48,13 @@ public class ClassificationCounter implements Serializable {
 	}
 
 	public void addClassification(final Serializable classification, double weight) {
-		Double c = counts.get(classification);
-		if (c == null) {
-			c = 0.0;
-		}
+		double c = counts.getDouble(classification); // should return 0.0 on absent values
 		total+= weight;
 		counts.put(classification, c + weight);
 	}
 
 	public double getCount(final Serializable classification) {
-		final Double c = counts.get(classification);
-		if (c == null)
-			return 0.0;
-		else
-			return c;
+		return counts.getDouble(classification);
 	}
 
 	public Set<Serializable> allClassifications() {
@@ -70,8 +64,8 @@ public class ClassificationCounter implements Serializable {
 	public ClassificationCounter add(final ClassificationCounter other) {
 		final ClassificationCounter result = new ClassificationCounter();
 		result.counts.putAll(counts);
-		for (final Entry<Serializable, Double> e : other.counts.entrySet()) {
-			result.counts.put(e.getKey(), getCount(e.getKey()) + e.getValue());
+		for (final Object2DoubleMap.Entry<Serializable> e : other.counts.object2DoubleEntrySet()) {
+			result.counts.put(e.getKey(), getCount(e.getKey()) + e.getDoubleValue());
 		}
 		result.total = total + other.total;
 		return result;
@@ -79,8 +73,8 @@ public class ClassificationCounter implements Serializable {
 
 	public ClassificationCounter subtract(final ClassificationCounter other) {
 		final ClassificationCounter result = new ClassificationCounter();
-		for (final Entry<Serializable, Double> e : counts.entrySet()) {
-			result.counts.put(e.getKey(), e.getValue() - other.getCount(e.getKey()));
+		for (final Object2DoubleMap.Entry<Serializable> e : counts.object2DoubleEntrySet()) {
+			result.counts.put(e.getKey(), e.getDoubleValue() - other.getCount(e.getKey()));
 		}
 		result.total = total - other.total;
 		return result;
@@ -91,9 +85,9 @@ public class ClassificationCounter implements Serializable {
 	}
 
 	public Pair<Serializable, Double> mostPopular() {
-		Entry<Serializable, Double> best = null;
-		for (final Entry<Serializable, Double> e : counts.entrySet()) {
-			if (best == null || e.getValue() > best.getValue()) {
+		Object2DoubleMap.Entry<Serializable> best = null;
+		for (final Object2DoubleMap.Entry<Serializable> e : counts.object2DoubleEntrySet()) {
+			if (best == null || e.getDoubleValue() > best.getDoubleValue()) {
 				best = e;
 			}
 		}

--- a/src/main/java/quickdt/Leaf.java
+++ b/src/main/java/quickdt/Leaf.java
@@ -1,8 +1,9 @@
 package quickdt;
 
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+
 import java.io.PrintStream;
 import java.io.Serializable;
-import java.util.Map;
 import java.util.Set;
 
 public class Leaf extends Node {
@@ -22,29 +23,28 @@ public class Leaf extends Node {
      */
     public final ClassificationCounter classificationCounts;
 
-    protected transient volatile Map.Entry<Serializable, Double> bestClassificationEntry = null;
+    protected transient volatile Object2DoubleMap.Entry<Serializable> bestClassificationEntry = null;
 
     public Leaf(Node parent, final Iterable<? extends AbstractInstance> instances, final int depth) {
-		super(parent);
+        super(parent);
         classificationCounts = ClassificationCounter.countAll(instances);
-         exampleCount = classificationCounts.getTotal();
-         this.depth = depth;
-	}
+        exampleCount = classificationCounts.getTotal();
+        this.depth = depth;
+    }
 
     /**
      *
      * @return The most likely classification
      */
-
     public Serializable getBestClassification() {
         return getBestClassificationEntry().getKey();
     }
 
-    protected synchronized Map.Entry<Serializable, Double> getBestClassificationEntry() {
+    protected synchronized Object2DoubleMap.Entry<Serializable> getBestClassificationEntry() {
         if (bestClassificationEntry != null) return bestClassificationEntry;
 
-        for (Map.Entry<Serializable, Double> e : classificationCounts.getCounts().entrySet()) {
-            if (bestClassificationEntry == null || e.getValue() > bestClassificationEntry.getValue()) {
+        for (Object2DoubleMap.Entry<Serializable> e : classificationCounts.getCounts().object2DoubleEntrySet()) {
+            if (bestClassificationEntry == null || e.getDoubleValue() > bestClassificationEntry.getDoubleValue()) {
                 bestClassificationEntry = e;
             }
         }

--- a/src/main/java/quickdt/OrdinalBranch.java
+++ b/src/main/java/quickdt/OrdinalBranch.java
@@ -10,9 +10,9 @@ public final class OrdinalBranch extends Branch {
     private static final  Logger logger =  LoggerFactory.getLogger(OrdinalBranch.class);
 
 	private static final long serialVersionUID = 4456176008067679801L;
-	public final double threshold;
+	public final float threshold;
 
-	public OrdinalBranch(Node parent, final String attribute, final double threshold) {
+	public OrdinalBranch(Node parent, final String attribute, final float threshold) {
 		super(parent, attribute);
 		this.threshold = threshold;
 
@@ -24,8 +24,8 @@ public final class OrdinalBranch extends Branch {
         if (!(value instanceof Number)) {
             throw new RuntimeException("Expecting a number as the value of "+attribute+" but got "+value +" of type "+value.getClass().getSimpleName());
         }
-        final double valueAsDouble = ((Number) value).doubleValue();
-		return valueAsDouble > threshold;
+        final float valueAsFloat = ((Number) value).floatValue();
+		return valueAsFloat > threshold;
 	}
 
 	@Override

--- a/src/main/java/quickdt/TreeBuilder.java
+++ b/src/main/java/quickdt/TreeBuilder.java
@@ -278,11 +278,13 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
     private boolean shouldWeIgnoreThisValue(final ClassificationCounter testValCounts) {
         double lowestClassificationCount = Double.MAX_VALUE;
         for (double classificationCount : testValCounts.getCounts().values()) {
+            // NOTE: when using fastutil-map backed collection counters, this will auto-box and -unbox the doubles.
+            // consider rewriting to a custom iterator-based loop when this turns out to be a performance issue.
             if (classificationCount < lowestClassificationCount) {
                 lowestClassificationCount = classificationCount;
             }
         }
-	    return lowestClassificationCount < this.minNominalAttributeValueOccurances;
+        return lowestClassificationCount < this.minNominalAttributeValueOccurances;
     }
 
     protected Pair<? extends Branch, Double> createOrdinalNode(Node parent, final String attribute,

--- a/src/main/java/quickdt/TreeBuilder.java
+++ b/src/main/java/quickdt/TreeBuilder.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.twitter.common.stats.ReservoirSampler;
-import com.twitter.common.util.*;
 import com.twitter.common.util.Random;
 import org.javatuples.Pair;
 import org.slf4j.Logger;
@@ -14,8 +13,13 @@ import org.slf4j.LoggerFactory;
 import quickdt.scorers.Scorer1;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
     private static final  Logger logger =  LoggerFactory.getLogger(TreeBuilder.class);
@@ -56,19 +60,19 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
         return new Tree(buildTree(null, trainingData, 0, createOrdinalSplits(trainingData)));
 	}
 
-	private double[] createOrdinalSplit(final Iterable<? extends AbstractInstance> trainingData, final String attribute) {
+	private float[] createOrdinalSplit(final Iterable<? extends AbstractInstance> trainingData, final String attribute) {
         logger.debug("Creating ordinal split for attribute {}", attribute);
-		final ReservoirSampler<Double> rs = new ReservoirSampler<Double>(1000, random);
+		final ReservoirSampler<Float> rs = new ReservoirSampler<Float>(1000, random);
 		for (final AbstractInstance i : trainingData) {
-			rs.sample(((Number) i.getAttributes().get(attribute)).doubleValue());
+			rs.sample(((Number) i.getAttributes().get(attribute)).floatValue());
 		}
-		final ArrayList<Double> al = Lists.newArrayList();
-		for (final Double d : rs.getSamples()) {
+		final ArrayList<Float> al = Lists.newArrayList();
+		for (final Float d : rs.getSamples()) {
 			al.add(d);
 		}
 		Collections.sort(al);
 
-		final double[] split = new double[ORDINAL_TEST_SPLITS - 1];
+		final float[] split = new float[ORDINAL_TEST_SPLITS - 1];
 		for (int x = 0; x < split.length; x++) {
 			split[x] = al.get((x + 1) * al.size() / (split.length + 1));
 		}
@@ -77,32 +81,32 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
 		return split;
 	}
 
-	private Map<String, double[]> createOrdinalSplits(final Iterable<? extends AbstractInstance> trainingData) {
+	private Map<String, float[]> createOrdinalSplits(final Iterable<? extends AbstractInstance> trainingData) {
         logger.debug("Creating ordinal splits");
-		final Map<String, ReservoirSampler<Double>> rsm = Maps.newHashMap();
+		final Map<String, ReservoirSampler<Float>> rsm = Maps.newHashMap();
 		for (final AbstractInstance i : trainingData) {
 			for (final Entry<String, Serializable> e : i.getAttributes().entrySet()) {
 				if (e.getValue() instanceof Number) {
-					ReservoirSampler<Double> rs = rsm.get(e.getKey());
+					ReservoirSampler<Float> rs = rsm.get(e.getKey());
 					if (rs == null) {
-						rs = new ReservoirSampler<Double>(1000, random);
+						rs = new ReservoirSampler<Float>(1000, random);
 						rsm.put(e.getKey(), rs);
 					}
-					rs.sample(((Number) e.getValue()).doubleValue());
+					rs.sample(((Number) e.getValue()).floatValue());
 				}
 			}
 		}
 
-		final Map<String, double[]> splits = Maps.newHashMap();
+		final Map<String, float[]> splits = Maps.newHashMap();
 
-		for (final Entry<String, ReservoirSampler<Double>> e : rsm.entrySet()) {
-			final ArrayList<Double> al = Lists.newArrayList();
-			for (final Double d : e.getValue().getSamples()) {
+		for (final Entry<String, ReservoirSampler<Float>> e : rsm.entrySet()) {
+			final ArrayList<Float> al = Lists.newArrayList();
+			for (final Float d : e.getValue().getSamples()) {
 				al.add(d);
 			}
 			Collections.sort(al);
 
-			final double[] split = new double[ORDINAL_TEST_SPLITS - 1];
+			final float[] split = new float[ORDINAL_TEST_SPLITS - 1];
 			for (int x = 0; x < split.length; x++) {
 				split[x] = al.get((x + 1) * al.size() / (split.length + 2));
 			}
@@ -113,7 +117,7 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
 	}
 
 	protected Node buildTree(Node parent, final Iterable<? extends AbstractInstance> trainingData, final int depth,
-                             final Map<String, double[]> splits) {
+                             final Map<String, float[]> splits) {
         logger.debug("Building tree at depth {}", depth);
 		final Leaf thisLeaf = new Leaf(parent, trainingData, depth);
 		if (depth == maxDepth || thisLeaf.getBestClassificationProbability() >= minProbability)
@@ -160,7 +164,7 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
 			// Its a bad sign when this happens, normally something to debug
 			return thisLeaf;
 
-		double[] oldSplit = null;
+		float[] oldSplit = null;
 
 		final LinkedList<? extends AbstractInstance> trueTrainingSet = Lists.newLinkedList(Iterables.filter(trainingData,
 				bestNode.getInPredicate()));
@@ -278,22 +282,19 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
                 lowestClassificationCount = classificationCount;
             }
         }
-        if (lowestClassificationCount < this.minNominalAttributeValueOccurances) {
-            return true;
-        }
-        return false;
+	    return lowestClassificationCount < this.minNominalAttributeValueOccurances;
     }
 
     protected Pair<? extends Branch, Double> createOrdinalNode(Node parent, final String attribute,
 			final Iterable<? extends AbstractInstance> instances,
-			final double[] splits) {
+			final float[] splits) {
         logger.debug("Creating ordinal node for attribute {}", attribute);
 
 		double bestScore = 0;
-		double bestThreshold = 0;
+		float bestThreshold = 0;
 
-		double lastThreshold = Double.MIN_VALUE;
-		for (final double threshold : splits) {
+		float lastThreshold = Float.MIN_VALUE;
+		for (final float threshold : splits) {
 			// Sometimes we can get a few thresholds the same, avoid wasted
 			// effort when we do
 			if (threshold == lastThreshold) {
@@ -305,7 +306,7 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
 				@Override
 				public boolean apply(final AbstractInstance input) {
 					try {
-						return ((Number) input.getAttributes().get(attribute)).doubleValue() > threshold;
+						return ((Number) input.getAttributes().get(attribute)).floatValue() > threshold;
 					} catch (final ClassCastException e) { // Kludge, need to
 						// handle better
 						return false;
@@ -317,7 +318,7 @@ public final class TreeBuilder implements PredictiveModelBuilder<Tree> {
 				@Override
 				public boolean apply(final AbstractInstance input) {
 					try {
-						return ((Number) input.getAttributes().get(attribute)).doubleValue() <= threshold;
+						return ((Number) input.getAttributes().get(attribute)).floatValue() <= threshold;
 					} catch (final ClassCastException e) { // Kludge, need to
 						// handle better
 						return false;


### PR DESCRIPTION
Use float instead of double as threshold in ordinal decision tree branches to reduce memory usage. 
Use fastutil Obj2Double maps to save memory in decision tree leaves. (primitive doubles use less memory than boxed Doubles). 

@ADiegoCAlonso @johannesu  